### PR TITLE
Implement deterministic noise and interactive navigation placeholder

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,15 +1,15 @@
 # Architecture Overview
 
-This scaffold establishes the wiring for a browser-based procedural world generator written in vanilla JavaScript. The initial focus is on organizing modules, defining responsibilities, and ensuring the rendering surface is ready for future simulation stages.
+This scaffold establishes the wiring for a browser-based procedural world generator written in vanilla JavaScript. The initial focus is on organizing modules, defining responsibilities, and ensuring the rendering surface is ready for future simulation stages. The placeholder renderer now leans on deterministic noise so pan/zoom and layer toggles can be exercised while deeper worldgen systems come online.
 
 ## Module Responsibilities
 
 - **`index.html`** — Declares the full-screen canvas (`#map`) and an overlay container for controls. Provides baseline styling to ensure an edge-to-edge viewport without scrollbars.
-- **`src/main.js`** — Boots the application, owns the top-level `state` object, wires UI events to state mutations, maintains the animation loop with an FPS meter, and forwards render calls to `render.js`. Also handles device-pixel-aware resizing so the canvas always matches the viewport.
+- **`src/main.js`** — Boots the application, owns the top-level `state` object, wires UI events to state mutations, maintains the animation loop with an FPS meter, and forwards render calls to `render.js`. It also manages device-pixel-aware resizing and pointer-driven pan/zoom (wheel zoom that focuses on the cursor, pointer-drag panning, and view resets when new seeds are applied).
 - **`src/ui.js`** — Builds the control bar (seed entry, regenerate button, layer toggles, FPS readout). Emits `CustomEvent`s (`ui:*`) that `main.js` consumes. Future UI agents will extend this module with import/export controls and debug overlays.
-- **`src/render.js`** — Receives state and view metadata to draw the current frame. The placeholder implementation rasterizes a deterministic color-LUT tile map into ImageData with device-pixel snapping so pan/zoom logic stays verifiable without binary assets. Later revisions will swap in biome-aware rendering pipelines.
+- **`src/render.js`** — Receives state and view metadata to draw the current frame. The placeholder implementation rasterizes seeded Simplex FBM noise into ImageData, derives biome tints, and applies optional overlays (rivers, lakes, contour hints) according to the UI toggles. The renderer still snaps to device pixels so pan/zoom interactions remain crisp.
 - **`src/worldgen.js`** — Placeholder factory for elevation fields. This module will orchestrate procedural world generation, eventually delegating to noise, hydrology, climate, and biome classification helpers.
-- **`src/noise.js`** — Houses the deterministic random number generator and fractal noise sampling utilities. Currently stubbed; will be implemented with Mulberry32 + Simplex FBM to guarantee reproducible worlds.
+- **`src/noise.js`** — Houses the deterministic random number generator and fractal noise sampling utilities. Mulberry32 provides seeded RNG streams and `noise2D` exposes a cached Simplex FBM sampler so every module can draw reproducible fields.
 - **`src/biomes.js`** — Placeholder biome classifier. Future agents will convert environmental fields (elevation, temperature, precipitation, moisture, hydrology flags) into biome identifiers via threshold tables and smoothing.
 - **`presets/temperate_hemisphere.json`** — Seed configuration slot for reusable parameter packs.
 - **`assets/.gitkeep`** — Keeps the assets directory tracked until art placeholders land.
@@ -27,8 +27,8 @@ No binary assets in PRs. Use inline SVG or data URIs when needed. Sprite atlas c
 4. **Biome classification** evaluates climate and hydrology fields to assign biome IDs, applying smoothing filters to prevent speckle.
 5. **Rendering** translates biome IDs and hydrology overlays into pixel colors, using a color-blind-safe palette and optional contour lines.
 
-Each stage feeds the next (`elevation → hydrology → climate → biomes → renderer`), ensuring clear separation of concerns and straightforward debugging.
+Each stage feeds the next (`elevation → hydrology → climate → biomes → renderer`), ensuring clear separation of concerns and straightforward debugging. The current placeholder renderer stands in for steps 2–5 by synthesizing pseudo-fields from deterministic noise so interaction plumbing can be validated.
 
 ## Determinism Plan
 
-All procedural steps will derive randomness from a single seeded RNG provided by `src/noise.js`. Once implemented, supplying the same seed (via the UI or preset JSON) will regenerate identical terrain, satisfying the determinism requirements outlined in `AGENTS.md`. Export/import routines will persist the seed, parameter packs, and version metadata so future runs can reproduce results bit-for-bit.
+All procedural steps derive randomness from the Mulberry32-based `createRng` helper and the cached Simplex FBM sampler exposed by `src/noise.js`. Supplying the same seed (via the UI or preset JSON) will regenerate identical terrain, satisfying the determinism requirements outlined in `AGENTS.md`. Export/import routines will persist the seed, parameter packs, and version metadata so future runs can reproduce results bit-for-bit.

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,9 @@
  * - marginPx: number — optional canvas padding around the render surface (default 0).
  * - FPS_SMOOTHING: number — exponential moving average factor for the FPS readout.
  * - FRAME_MAX_DT: number — clamp for delta time spikes in milliseconds.
+ * - MIN_ZOOM: number — lower bound for zoom level.
+ * - MAX_ZOOM: number — upper bound for zoom level.
+ * - ZOOM_SENSITIVITY: number — wheel delta multiplier controlling zoom speed.
  */
 import { initUI } from './ui.js';
 import { draw } from './render.js';
@@ -10,6 +13,9 @@ import { draw } from './render.js';
 const marginPx = 0;
 const FPS_SMOOTHING = 0.15;
 const FRAME_MAX_DT = 1000;
+const MIN_ZOOM = 0.4;
+const MAX_ZOOM = 16;
+const ZOOM_SENSITIVITY = 0.0015;
 
 const canvas = document.getElementById('map');
 const context = canvas.getContext('2d', { alpha: false, desynchronized: true });
@@ -17,6 +23,7 @@ if (!context) {
   throw new Error('Failed to acquire 2D rendering context for #map canvas.');
 }
 context.imageSmoothingEnabled = false;
+canvas.style.touchAction = 'none';
 
 const uiRoot = document.getElementById('ui-root');
 if (!uiRoot) {
@@ -41,6 +48,7 @@ const state = {
     width: window.innerWidth,
     height: window.innerHeight,
     margin: marginPx,
+    initialized: false,
   },
   frame: {
     fps: 0,
@@ -57,14 +65,14 @@ const ui = initUI(uiRoot, {
 uiRoot.addEventListener('ui:seed-change', (event) => {
   const { seed } = event.detail;
   state.seed = seed;
+  state.dirty = true;
   ui.updateState(state);
 });
 
 uiRoot.addEventListener('ui:regenerate', (event) => {
   const { seed } = event.detail;
   state.seed = seed;
-  // World generation will be triggered here once implemented.
-  state.dirty = true;
+  resetView();
   ui.updateState(state);
 });
 
@@ -77,13 +85,106 @@ uiRoot.addEventListener('ui:toggle-layer', (event) => {
   }
 });
 
+const activePointer = {
+  id: null,
+  lastX: 0,
+  lastY: 0,
+};
+
+canvas.addEventListener(
+  'pointerdown',
+  (event) => {
+    event.preventDefault();
+    canvas.setPointerCapture(event.pointerId);
+    activePointer.id = event.pointerId;
+    activePointer.lastX = event.clientX;
+    activePointer.lastY = event.clientY;
+  },
+  { passive: false },
+);
+
+canvas.addEventListener(
+  'pointermove',
+  (event) => {
+    if (activePointer.id !== event.pointerId) {
+      return;
+    }
+    const deltaX = event.clientX - activePointer.lastX;
+    const deltaY = event.clientY - activePointer.lastY;
+    if (deltaX === 0 && deltaY === 0) {
+      return;
+    }
+    activePointer.lastX = event.clientX;
+    activePointer.lastY = event.clientY;
+    state.view.panX += deltaX;
+    state.view.panY += deltaY;
+    state.dirty = true;
+  },
+  { passive: true },
+);
+
+function clearPointer(event) {
+  if (activePointer.id !== event.pointerId) {
+    return;
+  }
+  if (canvas.hasPointerCapture(event.pointerId)) {
+    canvas.releasePointerCapture(event.pointerId);
+  }
+  activePointer.id = null;
+}
+
+canvas.addEventListener('pointerup', clearPointer);
+canvas.addEventListener('pointercancel', clearPointer);
+canvas.addEventListener('pointerleave', clearPointer);
+
+canvas.addEventListener(
+  'wheel',
+  (event) => {
+    event.preventDefault();
+    const delta = event.deltaY;
+    if (delta === 0) {
+      return;
+    }
+
+    const zoomFactor = Math.exp(-delta * ZOOM_SENSITIVITY);
+    const targetZoom = clamp(state.view.zoom * zoomFactor, MIN_ZOOM, MAX_ZOOM);
+    if (targetZoom === state.view.zoom) {
+      return;
+    }
+
+    const rect = canvas.getBoundingClientRect();
+    const focusX = event.clientX - rect.left;
+    const focusY = event.clientY - rect.top;
+    applyZoom(focusX, focusY, targetZoom);
+  },
+  { passive: false },
+);
+
+function applyZoom(focusX, focusY, zoom) {
+  const previousZoom = clamp(state.view.zoom || 1, MIN_ZOOM, MAX_ZOOM);
+  const newZoom = clamp(zoom, MIN_ZOOM, MAX_ZOOM);
+  const ratio = newZoom / previousZoom;
+
+  state.view.panX = focusX - ratio * (focusX - state.view.panX);
+  state.view.panY = focusY - ratio * (focusY - state.view.panY);
+  state.view.zoom = newZoom;
+  state.dirty = true;
+}
+
+function resetView() {
+  state.view.zoom = 1;
+  state.view.panX = state.view.width / 2;
+  state.view.panY = state.view.height / 2;
+  state.dirty = true;
+}
+
 function resizeCanvas() {
   const { innerWidth, innerHeight } = window;
   const dpr = window.devicePixelRatio || 1;
   const cssWidth = Math.max(innerWidth - marginPx * 2, 0);
   const cssHeight = Math.max(innerHeight - marginPx * 2, 0);
-  const deviceWidth = Math.floor(cssWidth * dpr);
-  const deviceHeight = Math.floor(cssHeight * dpr);
+  const deviceWidth = Math.max(1, Math.floor(cssWidth * dpr));
+  const deviceHeight = Math.max(1, Math.floor(cssHeight * dpr));
 
   if (canvas.width !== deviceWidth || canvas.height !== deviceHeight) {
     canvas.width = deviceWidth;
@@ -94,9 +195,26 @@ function resizeCanvas() {
   canvas.style.height = `${cssHeight}px`;
   canvas.style.margin = `${marginPx}px`;
 
+  const previousWidth = state.view.width;
+  const previousHeight = state.view.height;
+
   state.view.pixelRatio = dpr;
   state.view.width = cssWidth;
   state.view.height = cssHeight;
+
+  if (!state.view.initialized) {
+    state.view.panX = cssWidth / 2;
+    state.view.panY = cssHeight / 2;
+    state.view.initialized = true;
+  } else {
+    if (Number.isFinite(previousWidth)) {
+      state.view.panX += (cssWidth - previousWidth) / 2;
+    }
+    if (Number.isFinite(previousHeight)) {
+      state.view.panY += (cssHeight - previousHeight) / 2;
+    }
+  }
+
   state.dirty = true;
 }
 
@@ -108,15 +226,14 @@ function updateFrameMetrics(now) {
     if (state.frame.fps === 0) {
       state.frame.fps = instantaneous;
     } else {
-      state.frame.fps =
-        state.frame.fps + FPS_SMOOTHING * (instantaneous - state.frame.fps);
+      state.frame.fps = state.frame.fps + FPS_SMOOTHING * (instantaneous - state.frame.fps);
     }
   }
   ui.updateFPS(state.frame.fps);
 }
 
 function renderFrame() {
-  const { pixelRatio, width, height } = state.view;
+  const { pixelRatio } = state.view;
   draw(state, {
     context,
     pixelRatio,
@@ -134,8 +251,13 @@ function tick(now) {
   window.requestAnimationFrame(tick);
 }
 
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
 function bootstrap() {
   resizeCanvas();
+  resetView();
   ui.updateState(state);
   window.addEventListener('resize', resizeCanvas, { passive: true });
   window.requestAnimationFrame(tick);

--- a/src/noise.js
+++ b/src/noise.js
@@ -3,33 +3,190 @@
  * - DEFAULT_OCTAVES: number — fallback octave count for fractal Brownian motion.
  * - DEFAULT_LACUNARITY: number — fallback lacunarity multiplier.
  * - DEFAULT_GAIN: number — fallback gain factor per octave.
+ * - DEFAULT_FREQUENCY: number — fallback base frequency in world units.
  */
-const DEFAULT_OCTAVES = 1;
+const DEFAULT_OCTAVES = 6;
 const DEFAULT_LACUNARITY = 2.0;
 const DEFAULT_GAIN = 0.5;
+const DEFAULT_FREQUENCY = 0.0015;
+
+const F2 = 0.5 * (Math.sqrt(3) - 1);
+const G2 = (3 - Math.sqrt(3)) / 6;
+const GRADIENTS = [
+  [1, 1],
+  [-1, 1],
+  [1, -1],
+  [-1, -1],
+  [1, 0],
+  [-1, 0],
+  [1, 0],
+  [-1, 0],
+  [0, 1],
+  [0, -1],
+  [0, 1],
+  [0, -1],
+];
+
+const permutationCache = new Map();
 
 /**
- * Sample placeholder 2D noise.
+ * Sample deterministic 2D Simplex FBM noise.
  * @param {number} x
  * @param {number} y
- * @param {{octaves?: number, lacunarity?: number, gain?: number, frequency?: number}} [options]
+ * @param {{octaves?: number, lacunarity?: number, gain?: number, frequency?: number, seed?: string|number}} [options]
  * @returns {number} A deterministic pseudo-noise value in the range [-1, 1].
  */
 export function noise2D(x, y, options = {}) {
-  void x;
-  void y;
-  void options;
-  // TODO: Implement Mulberry32-based Simplex FBM noise sampler.
-  return 0;
+  const {
+    octaves = DEFAULT_OCTAVES,
+    lacunarity = DEFAULT_LACUNARITY,
+    gain = DEFAULT_GAIN,
+    frequency = DEFAULT_FREQUENCY,
+    seed = 'default',
+  } = options;
+
+  const octaveCount = Math.max(1, Math.floor(Number.isFinite(octaves) ? octaves : DEFAULT_OCTAVES));
+  const lacunaritySafe = Number.isFinite(lacunarity) && lacunarity !== 0 ? lacunarity : DEFAULT_LACUNARITY;
+  const gainSafe = Number.isFinite(gain) ? gain : DEFAULT_GAIN;
+  let amplitude = 1;
+  let total = 0;
+  let normalization = 0;
+  let frequencySafe = Math.abs(Number.isFinite(frequency) ? frequency : DEFAULT_FREQUENCY);
+  if (frequencySafe === 0) {
+    frequencySafe = DEFAULT_FREQUENCY;
+  }
+
+  const perm = getPermutation(seed);
+
+  for (let octave = 0; octave < octaveCount; octave += 1) {
+    const sample = simplex2D(x * frequencySafe, y * frequencySafe, perm);
+    total += sample * amplitude;
+    normalization += amplitude;
+
+    amplitude *= gainSafe;
+    frequencySafe *= lacunaritySafe;
+
+    if (!Number.isFinite(amplitude) || amplitude <= 0) {
+      break;
+    }
+  }
+
+  if (normalization === 0) {
+    return 0;
+  }
+
+  return total / normalization;
 }
 
 /**
- * Create a deterministic random number generator (stub).
- * @param {number} seed
+ * Create a deterministic random number generator based on Mulberry32.
+ * Example usage:
+ * const rngA = createRng('demo-seed');
+ * const rngB = createRng('demo-seed');
+ * rngA() === rngB(); // always true for the same invocation count.
+ *
+ * @param {number|string} seed
  * @returns {() => number}
  */
 export function createRng(seed) {
-  void seed;
-  // TODO: Replace with Mulberry32 or similar high-quality seeded RNG.
-  return () => Math.random();
+  let state = normalizeSeed(seed);
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t ^= t + Math.imul(t ^ (t >>> 7), 61 | t);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function getPermutation(seed) {
+  const key = String(seed ?? 'default');
+  if (permutationCache.has(key)) {
+    return permutationCache.get(key);
+  }
+
+  const base = buildPermutation(normalizeSeed(key));
+  permutationCache.set(key, base);
+  return base;
+}
+
+function buildPermutation(seed) {
+  const source = new Uint8Array(256);
+  for (let i = 0; i < 256; i += 1) {
+    source[i] = i;
+  }
+
+  const rng = createRng(seed);
+  for (let i = 255; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1));
+    const temp = source[i];
+    source[i] = source[j];
+    source[j] = temp;
+  }
+
+  const perm = new Uint8Array(512);
+  for (let i = 0; i < 512; i += 1) {
+    perm[i] = source[i & 255];
+  }
+  return perm;
+}
+
+function simplex2D(x, y, perm) {
+  let n0 = 0;
+  let n1 = 0;
+  let n2 = 0;
+
+  const s = (x + y) * F2;
+  const i = Math.floor(x + s);
+  const j = Math.floor(y + s);
+  const t = (i + j) * G2;
+  const x0 = x - (i - t);
+  const y0 = y - (j - t);
+
+  const i1 = x0 > y0 ? 1 : 0;
+  const j1 = x0 > y0 ? 0 : 1;
+
+  const x1 = x0 - i1 + G2;
+  const y1 = y0 - j1 + G2;
+  const x2 = x0 - 1 + 2 * G2;
+  const y2 = y0 - 1 + 2 * G2;
+
+  const ii = i & 255;
+  const jj = j & 255;
+
+  let t0 = 0.5 - x0 * x0 - y0 * y0;
+  if (t0 > 0) {
+    t0 *= t0;
+    const grad0 = GRADIENTS[perm[ii + perm[jj]] % GRADIENTS.length];
+    n0 = t0 * t0 * (grad0[0] * x0 + grad0[1] * y0);
+  }
+
+  let t1 = 0.5 - x1 * x1 - y1 * y1;
+  if (t1 > 0) {
+    t1 *= t1;
+    const grad1 = GRADIENTS[perm[ii + i1 + perm[jj + j1]] % GRADIENTS.length];
+    n1 = t1 * t1 * (grad1[0] * x1 + grad1[1] * y1);
+  }
+
+  let t2 = 0.5 - x2 * x2 - y2 * y2;
+  if (t2 > 0) {
+    t2 *= t2;
+    const grad2 = GRADIENTS[perm[ii + 1 + perm[jj + 1]] % GRADIENTS.length];
+    n2 = t2 * t2 * (grad2[0] * x2 + grad2[1] * y2);
+  }
+
+  return 70 * (n0 + n1 + n2);
+}
+
+function normalizeSeed(seed) {
+  if (typeof seed === 'number' && Number.isFinite(seed)) {
+    return seed >>> 0;
+  }
+
+  const text = String(seed ?? '');
+  let hash = 2166136261 >>> 0;
+  for (let i = 0; i < text.length; i += 1) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
 }

--- a/src/render.js
+++ b/src/render.js
@@ -2,9 +2,17 @@
  * Parameters:
  * - COLOR_LUT: Uint8 RGBA tuples — placeholder biome colors chosen for color-blind safety.
  * - TILE_WORLD_SIZE: number — world-space size of the synthetic tile cells in CSS pixels.
- * - BIOME_BAND_HEIGHT: number — vertical span controlling broad color bands for variation.
+ * - BASE_NOISE_FREQUENCY: number — base frequency for elevation noise in world units.
+ * - MOISTURE_NOISE_SCALE: number — multiplier for secondary moisture noise frequency.
+ * - FLOW_NOISE_SCALE: number — multiplier for placeholder flow noise frequency.
+ * - LAKE_THRESHOLD: number — normalized elevation threshold for painting lakes.
+ * - RIVER_THRESHOLD: number — threshold on the placeholder flow mask for rivers.
+ * - CONTOUR_INTERVAL: number — normalized elevation step between contour bands.
+ * - CONTOUR_HALF_WIDTH: number — band half-width controlling contour line thickness.
  * - AXIS_COLOR: string — color of the origin crosshair overlay.
  */
+import { noise2D } from './noise.js';
+
 const COLOR_LUT = [
   [12, 24, 48, 255], // deep ocean
   [20, 54, 88, 255], // ocean shelf
@@ -17,8 +25,21 @@ const COLOR_LUT = [
 ];
 
 const TILE_WORLD_SIZE = 48;
-const BIOME_BAND_HEIGHT = TILE_WORLD_SIZE * 3;
+const BASE_NOISE_FREQUENCY = 0.0015;
+const MOISTURE_NOISE_SCALE = 1.75;
+const FLOW_NOISE_SCALE = 2.35;
+const LAKE_THRESHOLD = 0.34;
+const RIVER_THRESHOLD = 0.78;
+const CONTOUR_INTERVAL = 0.05;
+const CONTOUR_HALF_WIDTH = 0.014;
 const AXIS_COLOR = 'rgba(255, 255, 255, 0.18)';
+const LAKE_COLOR = [44, 96, 160];
+const RIVER_COLOR = [52, 136, 204];
+const LATITUDE_VARIATION = 1 / (TILE_WORLD_SIZE * 18);
+const MOISTURE_OFFSET_X = 4096.5;
+const MOISTURE_OFFSET_Y = -2048.25;
+const FLOW_OFFSET_X = -1638.4;
+const FLOW_OFFSET_Y = 987.2;
 
 let cachedImageData = null;
 let cachedWidth = 0;
@@ -78,26 +99,112 @@ function rasterize(imageData, state, pixelRatio) {
   const zoom = Math.max(view.zoom || 1, Number.EPSILON);
   const panX = view.panX || 0;
   const panY = view.panY || 0;
-  const invPixelRatio = 1 / pixelRatio;
-  const seedHash = hashSeed(String(state?.seed ?? ''));
+  const invPixelRatio = 1 / (pixelRatio || 1);
+
+  const seed = state?.seed ?? 'default';
+  const baseOptions = {
+    frequency: BASE_NOISE_FREQUENCY,
+    octaves: 5,
+    gain: 0.5,
+    lacunarity: 2.0,
+    seed,
+  };
+  const moistureOptions = {
+    frequency: BASE_NOISE_FREQUENCY * MOISTURE_NOISE_SCALE,
+    octaves: 4,
+    gain: 0.55,
+    lacunarity: 2.15,
+    seed: `${seed}-moisture`,
+  };
+  const flowOptions = {
+    frequency: BASE_NOISE_FREQUENCY * FLOW_NOISE_SCALE,
+    octaves: 3,
+    gain: 0.6,
+    lacunarity: 2.05,
+    seed: `${seed}-flow`,
+  };
+
+  const layers = state?.layers || {};
+  const showBiomes = layers.biomes !== false;
+  const showRivers = layers.rivers !== false;
+  const showLakes = layers.lakes !== false;
+  const showContours = layers.contours === true;
 
   let offset = 0;
   for (let y = 0; y < height; y += 1) {
     const cssY = y * invPixelRatio;
     const worldY = (cssY - panY) / zoom;
-    const cellY = Math.floor(worldY / TILE_WORLD_SIZE);
 
     let cssX = 0;
     for (let x = 0; x < width; x += 1) {
       const worldX = (cssX - panX) / zoom;
-      const cellX = Math.floor(worldX / TILE_WORLD_SIZE);
-      const colorIndex = sampleColorIndex(cellX, cellY, worldX, worldY, seedHash);
-      const color = COLOR_LUT[colorIndex];
 
-      data[offset] = color[0];
-      data[offset + 1] = color[1];
-      data[offset + 2] = color[2];
-      data[offset + 3] = color[3];
+      const elevation = noise2D(worldX, worldY, baseOptions);
+      const height01 = clamp01(0.5 * (elevation + 1));
+
+      let r;
+      let g;
+      let b;
+
+      if (showBiomes) {
+        const moistureValue = noise2D(
+          worldX + MOISTURE_OFFSET_X,
+          worldY + MOISTURE_OFFSET_Y,
+          moistureOptions,
+        );
+        const humidity = clamp01(0.5 * (moistureValue + 1));
+        const colorIndex = pickBiomeIndex(height01, humidity, worldY);
+        const color = COLOR_LUT[colorIndex];
+        r = color[0];
+        g = color[1];
+        b = color[2];
+      } else {
+        const grey = Math.round(lerp(36, 220, height01));
+        r = grey;
+        g = grey;
+        b = grey;
+      }
+
+      if (showLakes && height01 < LAKE_THRESHOLD) {
+        const lakeStrength = clamp01((LAKE_THRESHOLD - height01) / LAKE_THRESHOLD);
+        const blend = lakeStrength * 0.75;
+        r = blendChannel(r, LAKE_COLOR[0], blend);
+        g = blendChannel(g, LAKE_COLOR[1], blend);
+        b = blendChannel(b, LAKE_COLOR[2], blend);
+      }
+
+      if (showRivers) {
+        const flowNoise = noise2D(
+          worldX + FLOW_OFFSET_X,
+          worldY + FLOW_OFFSET_Y,
+          flowOptions,
+        );
+        const riverMask = clamp01(1 - Math.abs(flowNoise));
+        if (riverMask > RIVER_THRESHOLD && height01 >= LAKE_THRESHOLD) {
+          const strength = clamp01((riverMask - RIVER_THRESHOLD) / (1 - RIVER_THRESHOLD));
+          const mix = 0.4 + strength * 0.5;
+          r = blendChannel(r, RIVER_COLOR[0], mix);
+          g = blendChannel(g, RIVER_COLOR[1], mix);
+          b = blendChannel(b, RIVER_COLOR[2], mix);
+        }
+      }
+
+      if (showContours) {
+        const contour = height01 / CONTOUR_INTERVAL;
+        const distance = Math.abs(contour - Math.round(contour));
+        const halfWidth = CONTOUR_HALF_WIDTH / Math.max(zoom, 1);
+        if (distance < halfWidth) {
+          const darkness = 0.55;
+          r = Math.max(0, Math.round(r * darkness));
+          g = Math.max(0, Math.round(g * darkness));
+          b = Math.max(0, Math.round(b * darkness));
+        }
+      }
+
+      data[offset] = r;
+      data[offset + 1] = g;
+      data[offset + 2] = b;
+      data[offset + 3] = 255;
       offset += 4;
 
       cssX += invPixelRatio;
@@ -105,23 +212,30 @@ function rasterize(imageData, state, pixelRatio) {
   }
 }
 
-function sampleColorIndex(cellX, cellY, worldX, worldY, seedHash) {
-  const latBand = positiveMod(Math.floor(worldY / BIOME_BAND_HEIGHT), COLOR_LUT.length);
-  const gradient = Math.sin(worldX * 0.02) + Math.cos(worldY * 0.015);
-  let gradientOffset = 0;
-  if (gradient > 0.9) {
-    gradientOffset = 2;
-  } else if (gradient > 0.35) {
-    gradientOffset = 1;
-  } else if (gradient < -0.9) {
-    gradientOffset = -2;
-  } else if (gradient < -0.35) {
-    gradientOffset = -1;
+function pickBiomeIndex(height01, humidity, worldY) {
+  if (height01 < 0.24) {
+    if (height01 < 0.15) return 0;
+    if (height01 < 0.2) return 1;
+    return 2;
+  }
+  if (height01 < 0.32) {
+    return 3;
+  }
+  if (height01 > 0.82) {
+    return 7;
   }
 
-  const jitter = (pseudoRandom(cellX, cellY, seedHash) % 3) - 1; // -1, 0, 1
-  const index = positiveMod(latBand + gradientOffset + jitter, COLOR_LUT.length);
-  return index;
+  const latitude = clamp01(0.5 + 0.5 * Math.sin(worldY * LATITUDE_VARIATION));
+  const humidityBias = clamp01(humidity + (0.5 - latitude) * 0.25);
+  const dryness = clamp01(1 - humidityBias + height01 * 0.15);
+
+  if (dryness < 0.33) {
+    return 4;
+  }
+  if (dryness < 0.66) {
+    return 5;
+  }
+  return 6;
 }
 
 function drawAxes(ctx, { viewportWidth, viewportHeight, panX, panY, zoom, pixelRatio }) {
@@ -142,24 +256,18 @@ function drawAxes(ctx, { viewportWidth, viewportHeight, panX, panY, zoom, pixelR
   ctx.restore();
 }
 
-function hashSeed(seed) {
-  let hash = 2166136261 >>> 0;
-  for (let i = 0; i < seed.length; i += 1) {
-    hash ^= seed.charCodeAt(i);
-    hash = Math.imul(hash, 16777619);
-  }
-  return hash >>> 0;
+function blendChannel(base, overlay, alpha) {
+  return Math.round(base * (1 - alpha) + overlay * alpha);
 }
 
-function pseudoRandom(x, y, seedHash) {
-  let h = seedHash ^ Math.imul(x, 374761393) ^ Math.imul(y, 668265263);
-  h = Math.imul(h ^ (h >>> 13), 1274126177);
-  return (h ^ (h >>> 16)) >>> 0;
+function lerp(a, b, t) {
+  return a + (b - a) * t;
 }
 
-function positiveMod(value, modulus) {
-  const mod = modulus <= 0 ? 1 : modulus;
-  return ((value % mod) + mod) % mod;
+function clamp01(value) {
+  if (value <= 0) return 0;
+  if (value >= 1) return 1;
+  return value;
 }
 
 function snapToDevice(value, pixelRatio) {


### PR DESCRIPTION
## Summary
- implement Mulberry32-based RNG and cached Simplex FBM sampler for `noise2D`
- add pointer pan/zoom handling and seeded view resets in `main.js`
- render seeded FBM placeholder terrain with toggle-driven overlays and document the deterministic pipeline

## Testing
- npm test *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68cb5ca58c3083329c3a5dbbd1a1725c