### PR TITLE
Document dark theme Tailwind guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,4 +17,13 @@ Extras:
   tertiary: #f53d9d
   quaternary: #ebccff
   quinary: #ec99ff
+  The application must ship solely with a dark theme. Favor rich charcoal and obsidian
+  background tones (e.g., #0c0c0f to #16161d) that create depth without sacrificing
+  readability. Use the primary through quinary colors as vibrant accent highlights for
+  interactive states, focus rings, key icons, and data visualization while ensuring all
+  text and essential UI elements meet or exceed WCAG AA contrast requirements.
+  Draw inspiration from terminal "ricing" aesthetics—glow effects, subtle noise, and
+  minimal neon pops are welcome. Feel free to introduce additional complementary accent
+  hues when needed, provided they maintain accessible contrast against the dark base and
+  harmonize with the established palette.
 - Human-centered Design: https://lawsofux.com/


### PR DESCRIPTION
## Summary
- expand the Tailwind customization instructions in AGENTS.md to require a dark-only theme
- describe preferred dark background tones and how to apply the primary–quinary colors as accessible accents
- encourage inspiration from terminal ricing aesthetics while allowing complementary colors that meet WCAG contrast

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d976635c708332ad673fdb31aa5bd1